### PR TITLE
Home page title rebrand

### DIFF
--- a/website/src/components/Button.tsx
+++ b/website/src/components/Button.tsx
@@ -7,7 +7,7 @@ type ButtonProps =
 
 export function Button({ className, ...props }: ButtonProps) {
   className = cn(
-    "inline-flex justify-center rounded-2xl bg-blue-600 p-2 px-4 text-base font-semibold text-white hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 active:text-white/70",
+    "inline-flex justify-center text-center rounded-2xl bg-blue-600 p-2 px-4 text-base font-semibold text-white hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 active:text-white/70",
     className,
   );
 

--- a/website/src/components/Contact.tsx
+++ b/website/src/components/Contact.tsx
@@ -3,17 +3,16 @@ import { Container } from "@/components/Container";
 import { NumberTitle } from "@/components/Number";
 import { spotifyPlaylistLink, tallyFormLink } from "@/const";
 import ArrowRight from "@/images/logos/arrow-right.svg";
+import { PageTitle } from "@/components/PageTitle";
 
 export const Contact = () => {
   return (
     <Container className="relative">
       <div className="mx-auto max-w-2xl lg:max-w-4xl lg:px-12">
-        <h1 className="font-display mb-8 text-5xl font-bold tracking-tighter text-blue-600 sm:text-7xl">
-          Contact & Feedback
-        </h1>
+        <PageTitle content="Contact & Feedback" />
 
         <div className="mb-8">
-          <h2 className="font-display align-center mb-2 flex gap-2 text-2xl tracking-tight text-blue-900">
+          <h2 className="font-display align-center mb-2 flex gap-2 text-xl tracking-tight text-blue-900 sm:text-2xl">
             <NumberTitle number="1" /> Tu veux contacter l'organisateur ?
           </h2>
           <p className="font-display tracking-tight text-blue-900">
@@ -29,8 +28,9 @@ export const Contact = () => {
         </div>
 
         <div className="mb-8">
-          <h2 className="font-display align-center mb-2 flex gap-2 text-2xl tracking-tight text-blue-900">
-            <NumberTitle number="2" /> Si tu veux aider à améliorer le meetup, remplis le sondage:
+          <h2 className="font-display align-center mb-2 flex gap-2 text-xl tracking-tight text-blue-900 sm:text-2xl">
+            <NumberTitle number="2" /> Si tu veux aider à améliorer le meetup, remplis le
+            formulaire:
           </h2>
           <p className="font-display mb-4 tracking-tight text-blue-900">
             <Link href={tallyFormLink} className="text-blue-500 underline hover:underline-offset-2">
@@ -40,7 +40,7 @@ export const Contact = () => {
         </div>
 
         <div className="mb-8">
-          <h3 className="font-display align-center mb-2 flex gap-2 text-2xl tracking-tight text-blue-900">
+          <h3 className="font-display align-center mb-2 flex gap-2 text-xl tracking-tight text-blue-900 sm:text-2xl">
             <NumberTitle number="3" /> Est-ce que tu veux faire un talk au Code @ Québec ?
           </h3>
           <p className="font-display tracking-tight text-blue-900">

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -27,7 +27,7 @@ export function Footer() {
             </Link>
           </div>
         </div>
-        <p className="mt-6 text-base text-gray-400 md:mt-0">
+        <p className="mt-6 text-sm text-gray-400 sm:text-base md:mt-0">
           Organisé par{" "}
           <Link
             href="https://michaelmasson.com"

--- a/website/src/components/Guidelines.tsx
+++ b/website/src/components/Guidelines.tsx
@@ -1,13 +1,12 @@
 import Link from "next/link";
 import { Container } from "@/components/Container";
+import { PageTitle } from "@/components/PageTitle";
 
 export const Guidelines = () => {
   return (
     <Container className="relative">
-      <h1 className="font-display text-center text-3xl font-bold tracking-tighter text-blue-600 sm:text-4xl">
-        Guidelines des talks au Code @ Québec
-      </h1>
-      <div className="font-display mt-6 mr-auto ml-auto max-w-4xl space-y-6 text-xl tracking-tight text-blue-900">
+      <PageTitle content="Guidelines des talks au Code @ Québec" />
+      <div className="font-display mr-auto ml-auto max-w-4xl space-y-6 text-justify text-lg tracking-tight text-blue-900 sm:text-xl">
         <p>
           Premièrement, merci de faire un talk au <b>Code @ Québec</b>. J&apos;ai fait ce document
           pour aider à préparer un talk pour le meetup et expliquer l&apos;ambiance qu&apos;on

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -10,6 +10,7 @@ import { formatCodeAQuebecLink, formatRelativeDate, getLastThursdayOfMonth } fro
 export function Header() {
   const nextLastThursday = getLastThursdayOfMonth();
   const eventLink = formatCodeAQuebecLink(nextLastThursday);
+  const nextLastThursdayLabel = formatRelativeDate(nextLastThursday);
 
   return (
     <header className="relative z-50 flex-none lg:pt-11">
@@ -21,22 +22,25 @@ export function Header() {
             </Link>
           </div>
         </div>
-        <div className="relative order-first -mx-4 flex flex-auto basis-full border-b border-blue-600/10 py-4 font-mono text-sm whitespace-nowrap text-blue-600 sm:-mx-6 lg:order-none lg:mx-0 lg:basis-auto lg:border-0 lg:py-0">
-          <div>
-            <div className="mx-auto flex items-center gap-2 px-4">
-              <p>Prochain meetup</p>-
-              <time dateTime={nextLastThursday.toISOString().slice(0, 10)}>
-                {nextLastThursday.toLocaleDateString("fr-CA", {
-                  weekday: "long",
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })}
-              </time>
-              <DiamondIcon className="h-1.5 w-1.5 overflow-visible fill-current stroke-current" />
+        <div className="relative order-first -mx-4 flex flex-auto basis-full whitespace-nowrap border-b border-blue-600/10 py-4 font-mono text-sm text-blue-600 sm:-mx-6 lg:order-none lg:mx-0 lg:basis-auto lg:border-0 lg:py-0">
+          <div className="mx-auto flex flex-wrap items-center justify-center gap-2">
+            <p>Prochain meetup</p>-
+            <time dateTime={nextLastThursday.toISOString().slice(0, 10)}>
+              {nextLastThursday.toLocaleDateString("fr-CA", {
+                weekday: "long",
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </time>
+            <div className="flex basis-full items-center justify-center gap-2 sm:basis-auto">
               <p>Québec, QC</p>
+              <DiamondIcon className="h-1.5 w-1.5 overflow-visible fill-current stroke-current sm:order-first" />
+              <p className="font-comic sm:hidden">{nextLastThursdayLabel}</p>
             </div>
-            <div className="font-comic text-center">{formatRelativeDate(nextLastThursday)}</div>
+            <p className="font-comic hidden basis-full text-center sm:block">
+              {nextLastThursdayLabel}
+            </p>
           </div>
         </div>
         <div className="hidden sm:mt-10 sm:flex lg:mt-0 lg:grow lg:basis-0 lg:justify-end">

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -14,7 +14,7 @@ export function Hero() {
     <div className="relative py-20 sm:pt-24 sm:pb-24">
       <Container className="relative">
         <div className="mx-auto max-w-2xl lg:max-w-4xl lg:px-12">
-          <h1 className="bg-gradient-to-b from-blue-600 to-transparent bg-clip-text pb-4 text-center text-4xl font-bold text-transparent uppercase sm:text-6xl lg:text-7xl">
+          <h1 className="bg-gradient-to-b from-blue-600 to-transparent bg-clip-text text-center text-4xl font-bold text-transparent uppercase sm:pb-4 sm:text-6xl lg:text-7xl">
             <span className="sr-only">C@Q - </span>Code @ Québec
           </h1>
           <div className="font-display mt-6 space-y-6 text-justify text-lg tracking-tight text-blue-900 sm:text-2xl">

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -28,7 +28,7 @@ export function Hero() {
               . L&apos;événement est ouvert à tous les devs de Québec. Vous pouvez trouver
               l&apos;événement sur la plateforme Eventbrite.
             </p>
-            <ButtonOutline href={eventLink} className="w-full gap-2" target="_blank">
+            <ButtonOutline href={eventLink} className="w-full flex-wrap gap-2" target="_blank">
               <span>Inscris-toi au prochain meetup</span>
               <span className="text-sm text-blue-500">(Ça coûte rien!)</span>
             </ButtonOutline>

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -17,7 +17,7 @@ export function Hero() {
           <h1 className="font-display text-5xl font-bold tracking-tighter text-blue-600 sm:text-7xl">
             <span className="sr-only">C@Q - </span>Code @ Québec
           </h1>
-          <div className="font-display mt-6 space-y-6 text-2xl tracking-tight text-blue-900">
+          <div className="font-display mt-6 space-y-6 text-justify text-lg tracking-tight text-blue-900 sm:text-2xl">
             <p>
               Le <b>Code @ Québec</b> est un meetup pour découvrir des technologies et rencontrer
               d&apos;autres devs. Chaque événement comprend <b>deux talks</b>, et les présentations

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -14,7 +14,7 @@ export function Hero() {
     <div className="relative py-20 sm:pt-24 sm:pb-24">
       <Container className="relative">
         <div className="mx-auto max-w-2xl lg:max-w-4xl lg:px-12">
-          <h1 className="font-display text-5xl font-bold tracking-tighter text-blue-600 sm:text-7xl">
+          <h1 className="bg-gradient-to-b from-blue-600 to-transparent bg-clip-text pb-4 text-center text-4xl font-bold text-transparent uppercase sm:text-6xl lg:text-7xl">
             <span className="sr-only">C@Q - </span>Code @ Québec
           </h1>
           <div className="font-display mt-6 space-y-6 text-justify text-lg tracking-tight text-blue-900 sm:text-2xl">

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -28,7 +28,7 @@ export function Hero() {
               . L&apos;événement est ouvert à tous les devs de Québec. Vous pouvez trouver
               l&apos;événement sur la plateforme Eventbrite.
             </p>
-            <ButtonOutline href={eventLink} className="w-full flex-wrap gap-2" target="_blank">
+            <ButtonOutline href={eventLink} className="w-full flex-wrap gap-x-2" target="_blank">
               <span>Inscris-toi au prochain meetup</span>
               <span className="text-sm text-blue-500">(Ça coûte rien!)</span>
             </ButtonOutline>

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -11,10 +11,10 @@ export function Hero() {
   const eventLink = formatCodeAQuebecLink(nextLastThursday);
 
   return (
-    <div className="relative py-20 sm:pt-36 sm:pb-24">
+    <div className="relative py-20 sm:pt-24 sm:pb-24">
       <Container className="relative">
         <div className="mx-auto max-w-2xl lg:max-w-4xl lg:px-12">
-          <h1 className="font-display text-5xl font-bold tracking-tighter text-blue-600 sm:text-7xl">
+          <h1 className="bg-gradient-to-b from-blue-600 to-transparent bg-clip-text pb-4 text-center text-4xl font-bold text-transparent uppercase sm:text-6xl lg:text-7xl">
             <span className="sr-only">C@Q - </span>Code @ Québec
           </h1>
           <div className="font-display mt-6 space-y-6 text-justify text-lg tracking-tight text-blue-900 sm:text-2xl">

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -14,7 +14,7 @@ export function Hero() {
     <div className="relative py-20 sm:pt-24 sm:pb-24">
       <Container className="relative">
         <div className="mx-auto max-w-2xl lg:max-w-4xl lg:px-12">
-          <h1 className="bg-gradient-to-b from-blue-600 to-transparent bg-clip-text pb-4 text-center text-4xl font-bold text-transparent uppercase sm:text-6xl lg:text-7xl">
+          <h1 className="font-display text-5xl font-bold tracking-tighter text-blue-600 sm:text-7xl">
             <span className="sr-only">C@Q - </span>Code @ Québec
           </h1>
           <div className="font-display mt-6 space-y-6 text-justify text-lg tracking-tight text-blue-900 sm:text-2xl">

--- a/website/src/components/PageTitle.tsx
+++ b/website/src/components/PageTitle.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+type PageTitleProps = {
+  content: string;
+};
+
+export function PageTitle({ content }: PageTitleProps) {
+  return (
+    <h1 className="font-display pb-6 text-center text-3xl font-bold tracking-tighter text-blue-600 sm:text-4xl">
+      {content}
+    </h1>
+  );
+}

--- a/website/src/components/Speakers.tsx
+++ b/website/src/components/Speakers.tsx
@@ -176,7 +176,7 @@ export function Speakers() {
                         ) : undefined}
                       </p>
                     </div>
-                    <div className="flex flex-col gap-y-3 text-center md:text-left">
+                    <div className="flex flex-col gap-y-3 text-justify">
                       <h3 className="font-display mt-4 flex gap-x-2 text-xl font-medium tracking-tight text-blue-900">
                         {talk.youtubeUrl ? (
                           <a href={talk.youtubeUrl} target="_blank" className="-mt-0.5">

--- a/website/src/components/Speakers.tsx
+++ b/website/src/components/Speakers.tsx
@@ -58,7 +58,7 @@ export function Speakers() {
           <h2 className="font-display text-4xl font-medium tracking-tighter text-blue-600 sm:text-5xl">
             Présentations
           </h2>
-          <p className="font-display mt-4 text-2xl tracking-tight text-blue-900">
+          <p className="font-display mt-4 text-lg tracking-tight text-blue-900 sm:text-2xl">
             Découvrez les personnes qui ont fait des présentations au Code @ Québec.
           </p>
         </div>
@@ -122,7 +122,7 @@ export function Speakers() {
               >
                 {event.talks.map((talk, talkIndex) => (
                   <div key={talkIndex} className="flex not-md:flex-col not-md:items-center">
-                    <div className="mr-4 w-80 flex-none">
+                    <div className="w-full max-w-80 flex-none md:mr-4">
                       <div className="group relative h-70 transform overflow-hidden rounded-4xl">
                         <div
                           className={cn(
@@ -176,7 +176,7 @@ export function Speakers() {
                         ) : undefined}
                       </p>
                     </div>
-                    <div className="flex flex-col gap-y-3 text-justify">
+                    <div className="flex flex-col gap-y-3">
                       <h3 className="font-display mt-4 flex gap-x-2 text-xl font-medium tracking-tight text-blue-900">
                         {talk.youtubeUrl ? (
                           <a href={talk.youtubeUrl} target="_blank" className="-mt-0.5">
@@ -202,7 +202,9 @@ export function Speakers() {
                         ) : undefined}
                         <span>{talk.title}</span>
                       </h3>
-                      <p className="text-base tracking-tight text-gray-600">{talk.summary}</p>
+                      <p className="text-justify text-base tracking-tight text-gray-600">
+                        {talk.summary}
+                      </p>
                       <div className="flex flex-col gap-2">
                         {talk.links.map((link, linkIndex) => (
                           <div key={linkIndex}>


### PR DESCRIPTION
Je jouais avec les couleurs pour le titre de la page principale. J'aimerais ajouter une transition d'entré subtile également dans le futur. Voici la suggestion pour le style :

**Avant:**
![image](https://github.com/user-attachments/assets/87fc54d0-3f38-4c9c-894e-c78424e68fa7)
![image](https://github.com/user-attachments/assets/2f073839-ee4f-400b-9d73-7c77acb1c56d)


**Après:**
![image](https://github.com/user-attachments/assets/744c845c-c5aa-41e2-8c5e-65f23429b6ee)
![image](https://github.com/user-attachments/assets/9c9ee764-39b4-4393-b589-04ce62506dc2)


Hésite pas à commenté sur les choix de design.